### PR TITLE
Save call to the catalogue service upon successful containerization

### DIFF
--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -4,11 +4,23 @@
   "description": "@naavre/containerizer-jupyterlab settings.",
   "type": "object",
   "properties": {
+    "virtualLab": {
+      "type": ["string"],
+      "title": "Virtual lab",
+      "description": "Slug of the current virtual lab (example: vl-my-project)",
+      "default": ""
+    },
     "containerizerServiceUrl": {
       "type": ["string"],
       "title": "Containerizer service URL",
       "description": "URL of the containerizer service (example: https://my-naavre.example.com/NaaVRE-containerizer-service)",
       "default": "/NaaVRE-containerizer-service"
+    },
+    "catalogueServiceUrl": {
+      "type": ["string"],
+      "title": "Catalogue service URL",
+      "description": "URL of the catalogue service (example: https://my-naavre.example.com/NaaVRE-catalogue-service)",
+      "default": "/NaaVRE-catalogue-service"
     }
   },
   "additionalProperties": false

--- a/src/VREPanel.tsx
+++ b/src/VREPanel.tsx
@@ -7,11 +7,15 @@ import { Slot } from '@lumino/signaling';
 import { Divider } from '@material-ui/core';
 
 export interface IVREPanelSettings {
+  virtualLab: string | null;
   containerizerServiceUrl: string | null;
+  catalogueServiceUrl: string | null;
 }
 
 export const DefaultVREPanelSettings: IVREPanelSettings = {
-  containerizerServiceUrl: null
+  virtualLab: null,
+  containerizerServiceUrl: null,
+  catalogueServiceUrl: null
 };
 
 export const VREPanelComponent = ({

--- a/src/components/CellDependenciesTable.tsx
+++ b/src/components/CellDependenciesTable.tsx
@@ -10,7 +10,11 @@ import {
 } from '@material-ui/core';
 
 interface ICellDependenciesTable {
-  items: [];
+  items: Array<{
+    name: string;
+    module?: string;
+    asname?: string;
+  }>;
 }
 
 export const CellDependenciesTable: React.FC<ICellDependenciesTable> = ({

--- a/src/components/CellIOTable.tsx
+++ b/src/components/CellIOTable.tsx
@@ -16,7 +16,7 @@ import CloseIcon from '@material-ui/icons/Close';
 
 interface ICellIOTable {
   title: string;
-  ioItems: [];
+  ioItems: Array<string>;
   nodeId: string;
   getType: (v: string) => string | null;
   updateType: (

--- a/src/components/CellTracker.tsx
+++ b/src/components/CellTracker.tsx
@@ -206,6 +206,12 @@ export class CellTracker extends React.Component<IProps, IState> {
         notebook: notebookModel.toJSON()
       }
     )
+      .then(resp => {
+        if (resp.status_code !== 200) {
+          throw `${resp.status_code} ${resp.reason}`;
+        }
+        return JSON.parse(resp.content);
+      })
       .then(data => {
         const extractedCell = data as VRECell;
         const typeSelections = this.getTypeSelections(extractedCell);

--- a/src/naavre-common/handler.ts
+++ b/src/naavre-common/handler.ts
@@ -5,7 +5,7 @@ import { ServerConnection } from '@jupyterlab/services';
 export interface INaaVREExternalServiceResponse {
   status_code: number;
   reason: string;
-  header: object;
+  headers: object;
   content: string;
 }
 

--- a/src/naavre-common/mockHandler.ts
+++ b/src/naavre-common/mockHandler.ts
@@ -206,9 +206,11 @@ const extractResponse = {
 };
 
 const containerizeResponse = {
-  wf_id: '7f798cdb-45fc-4db3-8293-5825147bdf56',
+  workflow_id: 'e347d158-389b-46c9-807d-bd0725d89fa3',
   dispatched_github_workflow: true,
-  image_version: '07b50c4'
+  image_version: '8d1b920',
+  workflow_url:
+    'https://github.com/QCDIS/NaaVRE-cells-test-3/actions/runs/11609137173/job/32325795875'
 };
 
 export async function MockNaaVREExternalService(
@@ -216,8 +218,8 @@ export async function MockNaaVREExternalService(
   url: string,
   headers = {},
   data = {}
-): Promise<INaaVREExternalServiceResponse | string | object> {
-  let resp: INaaVREExternalServiceResponse | string | object = {
+): Promise<INaaVREExternalServiceResponse> {
+  let resp: INaaVREExternalServiceResponse = {
     status_code: 404,
     reason: 'Cannot mock this request',
     header: {},
@@ -226,19 +228,39 @@ export async function MockNaaVREExternalService(
 
   if (url.endsWith('/NaaVRE-containerizer-service/base-image-tags')) {
     if (method === 'GET') {
-      resp = baseImageTagsResponse;
+      resp = {
+        status_code: 200,
+        reason: 'OK',
+        header: {},
+        content: JSON.stringify(baseImageTagsResponse)
+      };
     }
   } else if (url.endsWith('/NaaVRE-containerizer-service/extract')) {
     if (method === 'POST') {
-      resp = extractResponse;
+      resp = {
+        status_code: 200,
+        reason: 'OK',
+        header: {},
+        content: JSON.stringify(extractResponse)
+      };
     }
   } else if (url.endsWith('/NaaVRE-containerizer-service/containerize')) {
     if (method === 'POST') {
-      resp = containerizeResponse;
+      resp = {
+        status_code: 200,
+        reason: 'OK',
+        header: {},
+        content: JSON.stringify(containerizeResponse)
+      };
     }
   } else if (url.endsWith('/NaaVRE-catalogue-service/cells')) {
     if (method === 'POST') {
-      resp = {};
+      resp = {
+        status_code: 200,
+        reason: 'OK',
+        header: {},
+        content: JSON.stringify({})
+      };
     }
   }
 
@@ -251,6 +273,6 @@ export async function MockNaaVREExternalService(
     },
     response: resp
   });
-  await new Promise(r => setTimeout(r, 2000));
+  await new Promise(r => setTimeout(r, 500));
   return resp;
 }

--- a/src/naavre-common/mockHandler.ts
+++ b/src/naavre-common/mockHandler.ts
@@ -222,7 +222,7 @@ export async function MockNaaVREExternalService(
   let resp: INaaVREExternalServiceResponse = {
     status_code: 404,
     reason: 'Cannot mock this request',
-    header: {},
+    headers: {},
     content: ''
   };
 
@@ -231,7 +231,7 @@ export async function MockNaaVREExternalService(
       resp = {
         status_code: 200,
         reason: 'OK',
-        header: {},
+        headers: {},
         content: JSON.stringify(baseImageTagsResponse)
       };
     }
@@ -240,7 +240,7 @@ export async function MockNaaVREExternalService(
       resp = {
         status_code: 200,
         reason: 'OK',
-        header: {},
+        headers: {},
         content: JSON.stringify(extractResponse)
       };
     }
@@ -249,7 +249,7 @@ export async function MockNaaVREExternalService(
       resp = {
         status_code: 200,
         reason: 'OK',
-        header: {},
+        headers: {},
         content: JSON.stringify(containerizeResponse)
       };
     }
@@ -258,7 +258,7 @@ export async function MockNaaVREExternalService(
       resp = {
         status_code: 200,
         reason: 'OK',
-        header: {},
+        headers: {},
         content: JSON.stringify({})
       };
     }

--- a/src/naavre-common/types.ts
+++ b/src/naavre-common/types.ts
@@ -4,13 +4,17 @@ export declare type VRECell = {
   title: string;
   task_name: string;
   original_source: string;
-  inputs: [];
-  outputs: [];
-  params: [];
+  inputs: Array<string>;
+  outputs: Array<string>;
+  params: Array<string>;
   param_values: { [name: string]: string | null };
-  secrets: [];
-  confs: object;
-  dependencies: [];
+  secrets: Array<string>;
+  confs: { [name: string]: string };
+  dependencies: Array<{
+    name: string;
+    module?: string;
+    asname?: string;
+  }>;
   types: { [id: string]: string | null };
   chart_obj: IChart;
   node_id: string;

--- a/src/naavre-common/types.ts
+++ b/src/naavre-common/types.ts
@@ -20,8 +20,67 @@ export declare type VRECell = {
   node_id: string;
   container_source: string;
   global_conf: object;
-  base_image: { image: { build: string; runtime: string } } | null;
+  base_image: { build: string; runtime: string } | null;
   image_version: string;
   kernel: string;
   notebook_dict: object;
 };
+
+export namespace NaaVRECatalogue {
+  export namespace BaseAssets {
+    export interface IBaseAsset {
+      id?: string;
+      title: string;
+      description?: string;
+      created?: string;
+      modified?: string;
+      owner?: string;
+      virtual_lab?: string;
+    }
+  }
+  export namespace WorkflowCells {
+    interface IBaseImage {
+      build: string;
+      runtime: string;
+    }
+
+    interface IDependency {
+      name: string;
+      module?: string;
+      asname?: string;
+    }
+
+    interface IBaseVariable {
+      name: string;
+      type: string;
+    }
+
+    interface IInput extends IBaseVariable {}
+
+    interface IOutput extends IBaseVariable {}
+
+    interface IConf {
+      name: string;
+      assignation: string;
+    }
+
+    interface IParam extends IBaseVariable {
+      default_value?: string;
+    }
+
+    interface ISecret extends IBaseVariable {}
+
+    export interface ICell extends BaseAssets.IBaseAsset {
+      container_image: string;
+      base_container_image?: IBaseImage;
+      dependencies?: Array<IDependency>;
+      inputs?: Array<IInput>;
+      outputs?: Array<IOutput>;
+      confs?: Array<IConf>;
+      params?: Array<IParam>;
+      secrets?: Array<ISecret>;
+      kernel?: string;
+      source_url?: string;
+    }
+  }
+}

--- a/src/services/cellConverter.ts
+++ b/src/services/cellConverter.ts
@@ -1,0 +1,51 @@
+import { NaaVRECatalogue, VRECell } from '../naavre-common/types';
+import { IVREPanelSettings } from '../VREPanel';
+
+export function containerizerToCatalogueCell(
+  c: VRECell,
+  settings: IVREPanelSettings
+): NaaVRECatalogue.WorkflowCells.ICell {
+  return {
+    title: c.title,
+    description: '',
+    virtual_lab: settings.virtualLab || undefined,
+    base_container_image: c.base_image || undefined,
+    dependencies: c.dependencies,
+    inputs: c.inputs.map(e => {
+      return {
+        name: e,
+        type: c.types[e] || ''
+      };
+    }),
+    outputs: c.outputs.map(e => {
+      return {
+        name: e,
+        type: c.types[e] || ''
+      };
+    }),
+    confs: Object.entries(c.confs).map(([k, v]) => {
+      return {
+        name: k,
+        assignation: v
+      };
+    }),
+    params: c.params.map(e => {
+      return {
+        name: e,
+        type: c.types[e] || '',
+        default_value: c.param_values[e] || undefined
+      };
+    }),
+    secrets: c.secrets.map(e => {
+      return {
+        name: e,
+        type: c.types[e] || ''
+      };
+    }),
+    kernel: c.kernel,
+    // FIXME: the following values should come from backend because we don't
+    // FIXME: have enough information to infer them here
+    container_image: 'FIXME-dummy-container-image:latest', // docker image tag, including version
+    source_url: '' // link to the source folder on GitHub
+  };
+}


### PR DESCRIPTION
In this initial implementation, we convert the `Cell` object returned by the [`NaaVRE-containerizer-service`](https://github.com/NaaVRE/NaaVRE-containerizer-service) to the format required by the [`NaaVRE-catalogue-service`](https://github.com/NaaVRE/NaaVRE-catalogue-service). See [`src/services/cellConverter.ts`](https://github.com/NaaVRE/NaaVRE-containerizer-jupyterlab/blob/1b61330aa0f688a2ad2839a1656b6c0ffe701c37/src/services/cellConverter.ts) for the implementation.

In the future, I would like to use the same `Cell` model across all services. That would mean:
- changing the model in the containerizer service (NaaVRE/NaaVRE-containerizer-service#10)
- changing the [`VRECell`](https://github.com/NaaVRE/NaaVRE-containerizer-jupyterlab/blob/1b61330aa0f688a2ad2839a1656b6c0ffe701c37/src/naavre-common/types.ts#L3) type used for the frontend state