### PR TITLE
Continue containerization in the background

### DIFF
--- a/src/components/CellTracker.tsx
+++ b/src/components/CellTracker.tsx
@@ -346,7 +346,9 @@ export class CellTracker extends React.Component<IProps, IState> {
           settings={this.props.settings}
         />
       ) as Dialog.IBodyWidget<any>,
-      buttons: this.state.loading ? [] : [Dialog.okButton({ label: 'Close' })]
+      buttons: this.state.loading
+        ? []
+        : [Dialog.okButton({ label: 'Continue in the background' })]
     };
     showDialog(AddCellDialogOptions).then(() => {
       this.setState({ loading: false });


### PR DESCRIPTION
The containerizer service `POST /containerize` endpoint takes longer to complete than before the refactoring. This is because it waits for a response from GitHub in order to return the URL of the CI workflow, which is useful for user to debug containerization issues. However, the long waiting becomes an issue when re-containerizing many cells that are not expected to fail.

When closing the dialog, the containerization process continues in the background, and the cell is added to the catalogue upon success. By changing the label of the button from "Close" to "Continue in the background", we make this behavior explicit to the users. 