### PR TITLE
Reset tracker panel when cell content changes

### DIFF
--- a/src/components/CellTracker.tsx
+++ b/src/components/CellTracker.tsx
@@ -2,15 +2,13 @@ import * as React from 'react';
 import { NaaVREExternalService } from '../naavre-common/handler';
 import { CellPreview, cellsToChartNode } from '../naavre-common/CellPreview';
 import { NaaVRECatalogue } from '../naavre-common/types';
-import { INotebookModel, Notebook, NotebookPanel } from '@jupyterlab/notebook';
-import { Cell } from '@jupyterlab/cells';
+import { INotebookModel, NotebookPanel } from '@jupyterlab/notebook';
 import { theme } from '../Theme';
 import TableContainer from '@material-ui/core/TableContainer';
 import { Button, TextField, ThemeProvider } from '@material-ui/core';
 import { Alert, Autocomplete, Box, LinearProgress } from '@mui/material';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import { emptyChart } from '../naavre-common/emptyChart';
-import { Slot } from '@lumino/signaling';
 import { IVREPanelSettings } from '../VREPanel';
 import { CellIOTable } from './CellIOTable';
 import { CellDependenciesTable } from './CellDependenciesTable';
@@ -100,18 +98,12 @@ export class CellTracker extends React.Component<IProps, IState> {
     }
   };
 
-  onActiveCellChanged: Slot<Notebook, Cell | null> = async (
-    notebook,
-    _activeCell
-  ) => {
-    this.resetState();
-  };
-
   connectAndInitWhenReady = (notebook: NotebookPanel) => {
     notebook.context.ready.then(() => {
       if (this.props.notebook !== null) {
-        this.props.notebook.content.activeCellChanged.connect(
-          this.onActiveCellChanged
+        this.props.notebook.content.activeCellChanged.connect(this.resetState);
+        this.props.notebook.content.modelContentChanged.connect(
+          this.resetState
         );
       }
     });
@@ -140,7 +132,10 @@ export class CellTracker extends React.Component<IProps, IState> {
     if (preNotebookId !== notebookId) {
       if (prevProps.notebook) {
         prevProps.notebook.content.activeCellChanged.disconnect(
-          this.onActiveCellChanged
+          this.resetState
+        );
+        prevProps.notebook.content.modelContentChanged.disconnect(
+          this.resetState
         );
       }
       if (this.props.notebook) {


### PR DESCRIPTION
After changing the content of a cell, it needs to be re-analyzed before being re-containerized. However, the tracker panel is not cleared when the content of the cell is changed. This encourages users to click again on "containerize" without first clicking on "analyze cell". When doing this, a stale version of the cell is containerized. 

![image](https://github.com/user-attachments/assets/2fb648b9-0b6d-4e60-8968-d62763062792)

With this PR, we reset the tracker panel as soon as the cell content is changed, forcing users to click on "analyze cell" again. 

![image](https://github.com/user-attachments/assets/151d7452-37f4-47c0-b3e8-ee134eefb247)
