### PR TITLE
Display error message detail when failing to analyze a cell

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -2,7 +2,7 @@ name: naavre-containerizer-jl-dev
 
 services:
   containerizer-service:
-    image: ghcr.io/naavre/naavre-containerizer-service:v0.4.6
+    image: ghcr.io/naavre/naavre-containerizer-service:v0.4.7
     ports:
       - '127.0.0.1:41918:8000'
     environment:

--- a/src/components/CellTracker.tsx
+++ b/src/components/CellTracker.tsx
@@ -18,7 +18,8 @@ import {
   Box,
   Checkbox,
   LinearProgress,
-  Stack
+  Stack,
+  Typography
 } from '@mui/material';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import { emptyChart } from '../naavre-common/emptyChart';
@@ -27,6 +28,7 @@ import { CellIOTable } from './CellIOTable';
 import { CellDependenciesTable } from './CellDependenciesTable';
 import { detectType } from '../services/rTypes';
 import { createCell } from './CellCreation';
+import { Collapsible } from './Collapsible';
 
 interface IProps {
   notebook: NotebookPanel | null;
@@ -47,12 +49,17 @@ const DefaultCell: NaaVRECatalogue.WorkflowCells.ICell = {
   dependencies: []
 };
 
+interface IExtractorError {
+  message: string;
+  details: string;
+}
+
 interface IState {
   baseImageSelected: boolean;
   baseImages: any[];
   cellAnalyzed: boolean;
   currentCell: NaaVRECatalogue.WorkflowCells.ICell;
-  extractorError: string;
+  extractorError: string | IExtractorError;
   isDialogOpen: boolean;
   loading: boolean;
   typeSelections: { [type: string]: boolean };
@@ -210,7 +217,22 @@ export class CellTracker extends React.Component<IProps, IState> {
     )
       .then(resp => {
         if (resp.status_code !== 200) {
-          throw `${resp.status_code} ${resp.reason}`;
+          // Use http reason as default message
+          const error: IExtractorError = {
+            message: resp.reason,
+            details: JSON.stringify(resp)
+          };
+          // Use error message from the server if available
+          let data: { detail?: string };
+          try {
+            data = JSON.parse(resp.content);
+            if (data.detail !== undefined) {
+              error.message = data.detail;
+            }
+          } catch {
+            /* empty */
+          }
+          throw error;
         }
         return JSON.parse(resp.content);
       })
@@ -253,9 +275,22 @@ export class CellTracker extends React.Component<IProps, IState> {
       })
       .catch(reason => {
         console.log(reason);
+        let extractorError: string | IExtractorError;
+        if (typeof reason === 'string') {
+          extractorError = reason;
+        } else if (
+          reason !== null &&
+          typeof reason === 'object' &&
+          typeof reason.message === 'string' &&
+          typeof reason.details === 'string'
+        ) {
+          extractorError = reason as IExtractorError;
+        } else {
+          extractorError = String(reason);
+        }
         this.setState({
           loading: false,
-          extractorError: String(reason)
+          extractorError: extractorError
         });
       });
   };
@@ -412,11 +447,22 @@ export class CellTracker extends React.Component<IProps, IState> {
             </Stack>
           )}
           {this.state.extractorError && (
-            <div>
-              <Alert severity="error">
-                <p>Notebook cannot be analyzed: {this.state.extractorError}</p>
-              </Alert>
-            </div>
+            <Alert severity="error">
+              {typeof this.state.extractorError === 'string' ? (
+                <Typography variant="body2">
+                  {this.state.extractorError}
+                </Typography>
+              ) : (
+                <>
+                  <Typography variant="body2">
+                    {this.state.extractorError.message}
+                  </Typography>
+                  <Collapsible summary="Details" sx={{ mt: 3 }}>
+                    {this.state.extractorError.details}
+                  </Collapsible>
+                </>
+              )}
+            </Alert>
           )}
           {this.state.loading ? (
             <>

--- a/src/components/Collapsible.tsx
+++ b/src/components/Collapsible.tsx
@@ -1,0 +1,53 @@
+import React, { ReactNode, useState } from 'react';
+import { Box, ButtonBase, Collapse, SxProps, Typography } from '@mui/material';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+
+interface ICollapsible {
+  summary: ReactNode;
+  children: ReactNode;
+  sx?: SxProps;
+}
+
+export const Collapsible: React.FC<ICollapsible> = ({
+  summary,
+  children,
+  sx
+}) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Box sx={sx}>
+      <ButtonBase
+        onClick={() => setOpen(v => !v)}
+        disableRipple
+        sx={{
+          gap: 0.5
+        }}
+      >
+        <ChevronRightIcon
+          fontSize="small"
+          sx={{
+            color: 'text.secondary',
+            flexShrink: 0,
+            transition: 'transform 200ms ease',
+            transform: open ? 'rotate(90deg)' : 'rotate(0deg)'
+          }}
+        />
+        <Typography variant="body2">{summary}</Typography>
+      </ButtonBase>
+      <Collapse in={open} timeout={200}>
+        <Box
+          sx={{
+            mt: 0.5,
+            px: 2,
+            py: 1.5,
+            bgcolor: 'action.hover',
+            borderRadius: 1
+          }}
+        >
+          {children}
+        </Box>
+      </Collapse>
+    </Box>
+  );
+};


### PR DESCRIPTION
Display more informative error messages when failing to analyze a cell:

- Show the error message from the containerizer-service if it sends an HTTP error with a JSON-body containing a `detail` field. Example:

<img width="424" height="702" alt="image" src="https://github.com/user-attachments/assets/f86009d9-2da4-472f-999f-833f47ec4939" />

- Show the HTTP reason otherwise:

<img width="427" height="471" alt="image" src="https://github.com/user-attachments/assets/2cdc8bdf-4028-46c5-8ff8-fedbc22fbe37" />
